### PR TITLE
IA-3086: reconfigure sns notification topics

### DIFF
--- a/terraform/infrastructure-resources.tf
+++ b/terraform/infrastructure-resources.tf
@@ -66,3 +66,9 @@ data "aws_db_instance" "rds" {
 #data "aws_rds_cluster" "rds" {
 #  cluster_identifier = "${terraform.workspace}-hubzone-aurora"
 #}
+
+# sns notification topics
+data "aws_sns_topic" "alerts" {
+  for_each = toset(["green", "yellow", "red", "security"])
+  name     = "${local.account_name}-teams-${each.value}-notifications"
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -8,10 +8,14 @@ locals {
     prod = "222484291001"
   }
   sns_alarms = {
-    green    = "arn:aws:sns:us-east-1:502235151991:alarm-green"
-    yellow   = "arn:aws:sns:us-east-1:502235151991:alarm-yellow"
-    red      = "arn:aws:sns:us-east-1:502235151991:alarm-red"
-    security = "arn:aws:sns:us-east-1:502235151991:alarm-security"
+    #green    = "arn:aws:sns:us-east-1:502235151991:alarm-green"
+    #yellow   = "arn:aws:sns:us-east-1:502235151991:alarm-yellow"
+    #red      = "arn:aws:sns:us-east-1:502235151991:alarm-red"
+    #security = "arn:aws:sns:us-east-1:502235151991:alarm-security"
+    green    = data.aws_sns_topic.alerts["green"].arn
+    yellow   = data.aws_sns_topic.alerts["yellow"].arn
+    red      = data.aws_sns_topic.alerts["red"].arn
+    security = data.aws_sns_topic.alerts["security"].arn
   }
   all = {
     default = {


### PR DESCRIPTION
When I attempt to run a plan in `demo` its trying to roll back the Fargate Service to a previos task definition.
Looks good else where, but perhaps a good time to work it up thrugh the pipeline