### PR TITLE
IA-3231: update easy-fargate-service module ~>11.0

### DIFF
--- a/terraform/IA-3231.sh
+++ b/terraform/IA-3231.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+WORKSPACE=`terraform workspace show`
+SERVICE='hubzone-api'
+
+SGID=`aws ec2 describe-security-groups --query "SecurityGroups[?contains(GroupName, '${WORKSPACE}-${SERVICE}-fg-svc-sg') && starts_with(GroupName, '${WORKSPACE}')].GroupId" --output text`
+terraform import \
+  "module.api.aws_security_group_rule.fargate_egress" \
+  "${SGID}_egress_all_0_0_0.0.0.0/0"
+
+SGID=`aws ec2 describe-security-groups --query "SecurityGroups[?contains(GroupName, '${WORKSPACE}-${SERVICE}-fg-alb') && starts_with(GroupName, '${WORKSPACE}')].GroupId" --output text`
+terraform import \
+  "module.api.aws_security_group_rule.alb_egress" \
+  "${SGID}_egress_all_0_0_0.0.0.0/0"
+
+terraform import \
+  "module.api.aws_security_group_rule.alb_egress_ipv6[0]" \
+  "${SGID}_egress_all_0_0_::/0"

--- a/terraform/fargate.tf
+++ b/terraform/fargate.tf
@@ -18,7 +18,7 @@ locals {
 
 module "api" {
   source  = "USSBA/easy-fargate-service/aws"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   # cloudwatch logging
   log_group_name              = "/ecs/${terraform.workspace}/${local.env.service_name}"
@@ -34,6 +34,7 @@ module "api" {
   task_cpu               = local.env.task_cpu_rails
   task_memory            = local.env.task_memory_rails
   enable_execute_command = true
+  ipv6                   = false
   #alb_idle_timeout      = 60
 
   ## If the ecs task needs to access AWS API for any reason, grant


### PR DESCRIPTION
@bryaNgwa @rwhorton66 
This is an interal load balancer so there is no need for IPv6; however, it was in good pratice to update to the latest module version.

Note:
This PR has been applied to demo and stg.